### PR TITLE
make TLDraw demo auto-reconnect if backend goes away

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "jamsocket-tldraw-client",
       "version": "0.1.0",
       "dependencies": {
+        "@jamsocket/client": "^1.1.4",
         "@jamsocket/server": "^1.1.4",
         "@tldraw/sync": "^3.6.0",
         "@tldraw/sync-core": "^3.6.0",
@@ -620,6 +621,14 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@jamsocket/client": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@jamsocket/client/-/client-1.1.4.tgz",
+      "integrity": "sha512-cyp0aLaeUfrb+sE0odhOch83WYz/EL59+B9Uq4E4F8axF/1yYEPH15QV+HYdBrK7meAp06ZhZdx9/w9DVHHGvQ==",
+      "dependencies": {
+        "@jamsocket/types": "1.1.4"
       }
     },
     "node_modules/@jamsocket/server": {

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@jamsocket/client": "^1.1.4",
     "@jamsocket/server": "^1.1.4",
     "@tldraw/sync": "^3.6.0",
     "@tldraw/sync-core": "^3.6.0",

--- a/client/src/app/api/connect/route.ts
+++ b/client/src/app/api/connect/route.ts
@@ -1,0 +1,55 @@
+import { Jamsocket } from '@jamsocket/server'
+
+const JAMSOCKET_ACCOUNT = process.env.JAMSOCKET_ACCOUNT
+const JAMSOCKET_SERVICE = process.env.JAMSOCKET_SERVICE
+const JAMSOCKET_TOKEN = process.env.JAMSOCKET_TOKEN
+const JAMSOCKET_DEV = process.env.JAMSOCKET_DEV
+
+let jamsocket: Jamsocket
+if (JAMSOCKET_DEV) {
+  jamsocket = new Jamsocket({
+    dev: true,
+  })
+} else {
+  if (!JAMSOCKET_ACCOUNT || !JAMSOCKET_SERVICE || !JAMSOCKET_TOKEN) {
+    throw new Error(
+      'Missing environment variables JAMSOCKET_ACCOUNT, JAMSOCKET_SERVICE, or JAMSOCKET_TOKEN. ' +
+        'If you intend to run in local dev mode, set JAMSOCKET_DEV=true.',
+    )
+  }
+
+  jamsocket = new Jamsocket({
+    account: JAMSOCKET_ACCOUNT,
+    service: JAMSOCKET_SERVICE,
+    token: JAMSOCKET_TOKEN,
+  })
+}
+
+export async function POST(request: Request) {
+  const { docId } = await request.json()
+  if (typeof docId !== 'string') {
+    return Response.json({ error: 'docId is required in body' }, { status: 400 })
+  }
+
+  // This is a good place to check if the user has permissions
+  // to access the document! If they don't, you should return a 403 error here.
+  // For the sample code, we are assuming that every user can access every document.
+
+  const spawnResult = await jamsocket.connect({
+    key: docId,
+    spawn: {
+      executable: {
+        env: {
+          STORAGE_BUCKET: 'tldraw-jamsocket-demo',
+          STORAGE_PREFIX: docId,
+          // We recommend using Jamsocket's AWS integration in production, rather than
+          // passing credentials in as env vars, but it can be useful for testing.
+          // AWS_ACCESS_KEY_ID: '',
+          // AWS_SECRET_ACCESS_KEY: '',
+        },
+      },
+    },
+  })
+
+  return Response.json(spawnResult)
+}

--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -1,31 +1,5 @@
 import App from '@/components/App'
-import { Jamsocket } from '@jamsocket/server'
 import DocIdSetter from '../components/DocIdSetter'
-
-const JAMSOCKET_ACCOUNT = process.env.JAMSOCKET_ACCOUNT
-const JAMSOCKET_SERVICE = process.env.JAMSOCKET_SERVICE
-const JAMSOCKET_TOKEN = process.env.JAMSOCKET_TOKEN
-const JAMSOCKET_DEV = process.env.JAMSOCKET_DEV
-
-let jamsocket: Jamsocket
-if (JAMSOCKET_DEV) {
-  jamsocket = new Jamsocket({
-    dev: true,
-  })
-} else {
-  if (!JAMSOCKET_ACCOUNT || !JAMSOCKET_SERVICE || !JAMSOCKET_TOKEN) {
-    throw new Error(
-      'Missing environment variables JAMSOCKET_ACCOUNT, JAMSOCKET_SERVICE, or JAMSOCKET_TOKEN. ' +
-        'If you intend to run in local dev mode, set JAMSOCKET_DEV=true.',
-    )
-  }
-
-  jamsocket = new Jamsocket({
-    account: JAMSOCKET_ACCOUNT,
-    service: JAMSOCKET_SERVICE,
-    token: JAMSOCKET_TOKEN,
-  })
-}
 
 function randomDocId() {
   return Math.random().toString(36).substring(2, 15)
@@ -43,31 +17,9 @@ export default async function Home(props: Props) {
     docId = randomDocId()
   }
 
-  // This code runs on the server. It's a good place to check if the user has permissions
-  // to access the document! If they don't, you can return a 403 error here.
-  // For the sample code, we are assuming that every user can access every document.
-
-  const spawnResult = await jamsocket.connect({
-    key: docId,
-    spawn: {
-      executable: {
-        env: {
-          STORAGE_BUCKET: 'tldraw-jamsocket-demo',
-          STORAGE_PREFIX: docId,
-          // We recommend using Jamsocket's AWS integration in production, rather than
-          // passing credentials in as env vars, but it can be useful for testing.
-          // AWS_ACCESS_KEY_ID: '',
-          // AWS_SECRET_ACCESS_KEY: '',
-        },
-      },
-    },
-  })
-
-  const serverUrl = spawnResult.url.replace(/\/$/, '')
-
   return (
     <>
-      <App server={serverUrl} roomId={docId} />
+      <App roomId={docId} />
       <DocIdSetter docId={docId} />
     </>
   )

--- a/client/src/components/App.tsx
+++ b/client/src/components/App.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useSync } from '@tldraw/sync'
-import { useMemo } from 'react'
+import { useMemo, useEffect, useState } from 'react'
+import { SessionBackend, ConnectResponse } from '@jamsocket/client'
 import {
   AssetRecordType,
   Editor,
@@ -13,11 +14,45 @@ import {
 } from 'tldraw'
 
 interface AppProps {
-  server: string
   roomId: string
 }
 
-function App(props: AppProps) {
+export default function App(props: AppProps) {
+  const [connectResponse, setConnectResponse] = useState<ConnectResponse | null>(null)
+
+  useEffect(() => {
+    let sessionBackend: SessionBackend | null = null
+    let canceled = false
+    ;(async () => {
+      while (!canceled) {
+        const result = await fetch('/api/connect', {
+          method: 'POST',
+          body: JSON.stringify({ docId: props.roomId }),
+        })
+        const data = await result.json()
+        setConnectResponse(data)
+        sessionBackend = new SessionBackend(data)
+        await sessionBackend.onTerminatedPromise
+        sessionBackend.destroy()
+      }
+    })()
+    return () => {
+      canceled = true
+      if (sessionBackend) {
+        sessionBackend.destroy()
+      }
+    }
+  }, [props.roomId])
+
+  if (!connectResponse) {
+    return <div>Loading...</div>
+  }
+
+  const serverUrl = connectResponse.url.replace(/\/$/, '')
+  return <TldrawApp server={serverUrl} roomId={props.roomId} />
+}
+
+function TldrawApp(props: { server: string; roomId: string }) {
   let multiplayerAssets = useMemo(() => getMultiplayerAssets(props.server), [props.server])
 
   const store = useSync({
@@ -36,8 +71,6 @@ function App(props: AppProps) {
     </div>
   )
 }
-
-export default App
 
 function registerExternalAssetHandler(editor: Editor, server: string) {
   editor.registerExternalAssetHandler('url', async ({ url }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "jamsocket-tldraw-demo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Updating the demo to make the application reconnect to a new backend if the old one goes away.

Here's how it works:

1. Pull the session backend spawning logic (i.e. `jamsocket.connect()`) into an API endpoint that can be called from the client.
2. Use the endpoint in the client to start a session backend, then listen for when that session backend terminates.
3. If/when the session backend terminates, hit the API endpoint to start a new session backend and pass the new URL to the TLDraw application.